### PR TITLE
Upgrade pillow to 9.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ django-localflavor==3.1
 django-storages==1.12.3
 gunicorn==20.1.0
 jmespath==1.0.1
-Pillow==9.1.1
+Pillow==9.5.0
 psycopg2==2.9.3
 pycodestyle==2.8.0
 python-dateutil==2.8.2


### PR DESCRIPTION
It would not let me install requirements.txt with python 3.12 with the version of pillow in requirements.txt.
